### PR TITLE
Filename Fix patch

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -179,21 +179,21 @@ class MiscController extends AbstractController {
             return false;
         }
 
-		$corrected_name = pathinfo($_REQUEST['path'], 1) . "/" . rawurlencode( basename($_REQUEST['path']));
+		$corrected_name = pathinfo($_REQUEST['path'], PATHINFO_DIRNAME) . "/" . rawurlencode( basename($_GET['path']));
         $mime_type = FileUtils::getMimeType($corrected_name);
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         if ($mime_type === "application/pdf" || Utils::startsWith($mime_type, "image/")) {
             header("Content-type: ".$mime_type);
-            header('Content-Disposition: inline; filename="' .  basename($_REQUEST['path']) . '"');
+            header('Content-Disposition: inline; filename="' . rawurlencode(basename($_REQUEST['path'])) . '"');
             readfile($corrected_name);
-            $this->core->getOutput()->renderString($_REQUEST['path']);
+            $this->core->getOutput()->renderString(rawurlencode($_REQUEST['path']));
         }
         else {
             $contents = htmlentities(file_get_contents($corrected_name), ENT_SUBSTITUTE);
             if ($_REQUEST['ta_grading'] === "true") {
                 $filename = htmlentities($corrected_name, ENT_SUBSTITUTE);
-                $this->core->getOutput()->renderOutput('Misc', 'displayCode', $mime_type, $filename, $contents);
+               $this->core->getOutput()->renderOutput('Misc', 'displayCode', $mime_type, $corrected_name, $contents);
             }
             else {
                 $this->core->getOutput()->renderOutput('Misc', 'displayFile', $contents);

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -577,6 +577,8 @@ HTML;
                         $path_full = str_replace("_cover.pdf", ".pdf", $path);
                         $url_full = $this->core->getConfig()->getSiteUrl()."&component=misc&page=display_file&dir=uploads&file=".$filename_full."&path=".$path_full."&ta_grading=false";
                         $count_array[$count] = FileUtils::joinPaths($timestamp, $filename_full);
+                        //decode the filename after to display correctly for users
+                        $filename_full = rawurldecode($filename_full);
                         $return .= <<<HTML
             <tr class="tr tr-vertically-centered">
                 <td>{$count}</td>


### PR DESCRIPTION
- Uses PHP constant instead of 1, replaced $_REQUEST with $_GET to fix automatic PHP decoding

- Fixes display names for PDF preview 